### PR TITLE
Bump runtime app engine

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,8 +1,17 @@
-.gcloudignore
+.env**
+
+# Git stuffs
 .git
 .github
 
+# Nodejs dependencies
 node_modules/
-.env
 
-order.namaste-savannah/
+
+# Docker stuffs
+Dockerfile*
+docker-compose.yml
+
+# Dev dependencies
+db/seed/*
+md-seed-config.js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           mkdir deploy
           cat << EOF > ${{ github.workspace }}/app.yaml
-          runtime: nodejs10
+          runtime: nodejs14
           env: standard
           instance_class: F1
           handlers:


### PR DESCRIPTION
- Upgrade runtime from `nodejs10` to `nodejs14`\
- Add unnessary files to `.gcloudignore` to prevent being pushed to GCP 