### PR TITLE
Adsense fixes

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-8075216562373235, DIRECT, f08c47fec0942fa0

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/public/sellers.json
+++ b/public/sellers.json
@@ -1,0 +1,5 @@
+{
+  "seller_id": "pub-8075216562373235",
+  "is_confidential": "true",
+  "seller_type": "PUBLISHER"
+}

--- a/public/sellers.json
+++ b/public/sellers.json
@@ -1,5 +1,0 @@
-{
-  "seller_id": "pub-8075216562373235",
-  "is_confidential": "true",
-  "seller_type": "PUBLISHER"
-}


### PR DESCRIPTION
- Add `ads.txt` file to only allow Google AdSense.
- Add `robots.txt` to prevent rendering the 404 page for crawlers. Currently, the average latency for the page is ~800 ms.