### PR TITLE
Save tokens in database

### DIFF
--- a/db/actions/config.js
+++ b/db/actions/config.js
@@ -1,0 +1,33 @@
+const Config = require("../models/config");
+
+const EMAIL_TOKEN = "emailToken";
+
+async function getToken() {
+  return new Promise((resolve, reject) => {
+    Config.findOne({ key: EMAIL_TOKEN }, (err, token) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      return resolve(token);
+    });
+  });
+}
+
+async function saveToken(token) {
+  const newToken = await Config.findOneAndUpdate(
+    { key: EMAIL_TOKEN },
+    { value: token },
+    {
+      new: true,
+      upsert: true,
+    }
+  );
+  return newToken;
+}
+
+module.exports = {
+  getToken,
+  saveToken,
+};

--- a/db/models/config.js
+++ b/db/models/config.js
@@ -1,0 +1,10 @@
+const mongoose = require("mongoose");
+
+const configSchema = new mongoose.Schema({
+  key: { type: String, required: true, index: true },
+  value: { type: String, required: true },
+});
+
+const Config = mongoose.model("Config", configSchema);
+
+module.exports = Config;

--- a/public/js/contact.js
+++ b/public/js/contact.js
@@ -30,20 +30,18 @@ $(function () {
       },
     },
     submitHandler: async function (form) {
-      console.log("Submitting message frontend");
-
       // Remove any previous errors
       const button = $("button[type='submit']");
       button.text("Sending Message ...");
       button.removeClass("error");
 
+      // Parse form to get contact message
       const formData = $(form).serializeArray();
       const payload = {};
       formData.forEach((x) => {
         payload[x["name"]] = x["value"];
       });
 
-      console.log(payload);
       try {
         const response = await fetch("/contact", {
           headers: {
@@ -53,8 +51,6 @@ $(function () {
           method: "POST",
           body: JSON.stringify(payload),
         });
-
-        console.log(response);
 
         if (response.ok) {
           $("#contact-form-box input, #contact-form-box textarea").fadeTo(

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,9 +1,11 @@
-let express = require("express"),
+const express = require("express"),
   passport = require("passport");
 const Config = require("../db/models/config");
 
-let router = express.Router();
-let User = require("../db/models/user");
+const middleWare = require("../middleware");
+const { getAuthUrl, getNewToken } = require("../google/client");
+
+const router = express.Router();
 
 router.get("/login", (req, res) => {
   if (req.isAuthenticated()) {
@@ -82,6 +84,28 @@ router.get("/token", (req, res) => {
     console.log("No error yet");
     return res.status(200).json(doc);
   });
+});
+
+router.get(
+  "/admin/google/reset-email-token",
+  middleWare.isAuthorized,
+  async (req, res) => {
+    const authUrl = await getAuthUrl();
+    res.redirect(authUrl);
+  }
+);
+
+router.get("/admin/google/token", middleWare.isAuthorized, async (req, res) => {
+  const { code } = req.query;
+  if (code) {
+    try {
+      await getNewToken(code);
+    } catch (err) {
+      console.error(err);
+      return res.redirect("/error");
+    }
+  }
+  return res.redirect("/");
 });
 
 module.exports = router;

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,5 +1,6 @@
 let express = require("express"),
   passport = require("passport");
+const Config = require("../db/models/config");
 
 let router = express.Router();
 let User = require("../db/models/user");
@@ -71,6 +72,16 @@ router.get("/logout", (req, res) => {
   req.logout();
   req.flash("success", "Logged you out");
   res.redirect("/login");
+});
+
+router.get("/token", (req, res) => {
+  Config.findOne({ key: "emailToken" }, (err, doc) => {
+    if (err) {
+      return res.status(500).json(err);
+    }
+    console.log("No error yet");
+    return res.status(200).json(doc);
+  });
 });
 
 module.exports = router;

--- a/routes/contact.js
+++ b/routes/contact.js
@@ -1,5 +1,5 @@
 const express = require("express");
-const { getClient } = require("../google/client");
+const { getAuthenticatedClient } = require("../google/client");
 const { sendEmail } = require("../google/email");
 const router = express.Router();
 
@@ -26,7 +26,7 @@ router.post("/contact", async (req, res) => {
   );
 
   try {
-    const auth = await getClient();
+    const auth = await getAuthenticatedClient();
     const response = await sendEmail(auth, emailContent);
     console.log(response.status);
     if (response.status === 200) {

--- a/routes/contact.js
+++ b/routes/contact.js
@@ -28,7 +28,7 @@ router.post("/contact", async (req, res) => {
   try {
     const auth = await getAuthenticatedClient();
     const response = await sendEmail(auth, emailContent);
-    console.log(response.status);
+    
     if (response.status === 200) {
       return res.status(200).json({ status: "success" });
     }


### PR DESCRIPTION
Since it runs on App Engine (Standard Environment), it can scale down to 0 instances when no request comes in 15 minutes. Any new files created by this instance will be deleted when the instance dies. Similarly, when multiple instances are created due to high traffic, the temporary files will not be shared between instances.
Currently, the token is saved to a file that is not uploaded to App Engine as part of the source code. Hence, it would need to be created for each new instance which requires user interaction to be authenticated with Google OAuth. The purpose of this token is to use Gmail API on the server-side so authenticating with Google anytime a user tries to submit a message through the contact us page.

The purpose of this PR is to save the tokens in the database so that it can be shared between instances. Similarly, endpoints have been added to reset this token for admins if the token expires for some reason.

This also applies to Cloud Run where the containers needs to be stateless and any data that needs to be persisted should be saved externally, in this case, in the database.
